### PR TITLE
Support for attributes and Symfony 6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "doctrine/annotations": "~1.13",
+        "doctrine/annotations": "^1.13|^2.0",
         "jms/metadata": "~2.6",
         "jms/serializer": "~3.17",
         "symfony/dependency-injection": "~5.0",

--- a/composer.json
+++ b/composer.json
@@ -31,17 +31,17 @@
         "doctrine/annotations": "^1.13|^2.0",
         "jms/metadata": "~2.6",
         "jms/serializer": "~3.17",
-        "symfony/dependency-injection": "~5.0",
-        "symfony/event-dispatcher": "~5.0",
-        "symfony/expression-language": "~5.0",
-        "symfony/http-foundation": "~5.0",
-        "symfony/security-core": "~5.0",
-        "symfony/validator": "~5.0"
+        "symfony/dependency-injection": "6.4.*",
+        "symfony/event-dispatcher": "6.4.*",
+        "symfony/expression-language": "6.4.*",
+        "symfony/http-foundation": "6.4.*",
+        "symfony/security-core": "6.4.*",
+        "symfony/validator": "6.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "symfony/phpunit-bridge": "~5.0",
-        "symfony/stopwatch": "~5.0"
+        "symfony/phpunit-bridge": "6.4.*",
+        "symfony/stopwatch": "6.4.*"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require": {
-        "php": "8.0.*|8.1.*",
+        "php": "^8.0",
         "ext-json": "*",
         "doctrine/annotations": "~1.13",
         "jms/metadata": "~2.6",

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "symfony/validator": "6.4.*"
     },
     "require-dev": {
+        "koriym/attributes": "^1.0",
         "phpunit/phpunit": "^9.5",
         "symfony/phpunit-bridge": "6.4.*",
         "symfony/stopwatch": "6.4.*"

--- a/src/Annotation/Action.php
+++ b/src/Annotation/Action.php
@@ -9,6 +9,7 @@
 
 namespace TQ\ExtDirect\Annotation;
 
+use Doctrine\Common\Annotations\NamedArgumentConstructor;
 
 /**
  * Class Action
@@ -17,16 +18,13 @@ namespace TQ\ExtDirect\Annotation;
  *
  * @Annotation
  * @Target("CLASS")
+ * @NamedArgumentConstructor
  */
+#[\Attribute(\Attribute::TARGET_CLASS)]
 class Action
 {
-    /**
-     * @var string
-     */
-    public $serviceId;
-
-    /**
-     * @var string
-     */
-    public $alias;
+    public function __construct(
+        public ?string $serviceId = null,
+        public ?string $alias = null,
+    ) {}
 }

--- a/src/Annotation/Method.php
+++ b/src/Annotation/Method.php
@@ -9,6 +9,7 @@
 
 namespace TQ\ExtDirect\Annotation;
 
+use Doctrine\Common\Annotations\NamedArgumentConstructor;
 
 /**
  * Class Method
@@ -17,31 +18,16 @@ namespace TQ\ExtDirect\Annotation;
  *
  * @Annotation
  * @Target("METHOD")
+ * @NamedArgumentConstructor
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 class Method
 {
-    /**
-     * @var bool
-     */
-    public $formHandler = false;
-
-    /**
-     * @var bool
-     */
-    public $namedParams = false;
-
-    /**
-     * @var bool
-     */
-    public $strict = true;
-
-    /**
-     * @var mixed
-     */
-    public $batched = null;
-
-    /**
-     * @var bool
-     */
-    public $session = true;
+    public function __construct(
+        public bool $formHandler = false,
+        public bool $namedParams = false,
+        public bool $strict = true,
+        public mixed $batched = null,
+        public bool $session = true,
+    ) {}
 }

--- a/src/Annotation/Parameter.php
+++ b/src/Annotation/Parameter.php
@@ -9,6 +9,8 @@
 
 namespace TQ\ExtDirect\Annotation;
 
+use Doctrine\Common\Annotations\NamedArgumentConstructor;
+
 /**
  * Class Parameter
  *
@@ -16,90 +18,39 @@ namespace TQ\ExtDirect\Annotation;
  *
  * @Annotation
  * @Target("METHOD")
+ * @NamedArgumentConstructor
  */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Parameter
 {
-    /**
-     * @\Doctrine\Common\Annotations\Annotation\Required
-     *
-     * @var string
-     */
-    public $name;
+    public function __construct(
+        public string $name,
 
-    /**
-     * @var array<Symfony\Component\Validator\Constraint>
-     */
-    public $constraints = array();
+        /** @var string|array<Symfony\Component\Validator\Constraint> */
+        public string|array $constraints = [],
 
-    /**
-     * @var array<string>
-     */
-    public $validationGroups;
+        /** @var string|null|array<string> */
+        public string|null|array $validationGroups = null,
 
-    /**
-     * @var bool
-     */
-    public $strict = true;
+        public bool $strict = true,
 
-    /**
-     * @var array<string>
-     */
-    public $serializationGroups = [];
+        /** @var string|array<string> */
+        public string|array $serializationGroups = [],
 
-    /**
-     * @var array<string>
-     */
-    public $serializationAttributes = [];
+        /** @var string|array<string> */
+        public string|array $serializationAttributes = [],
 
-    /**
-     * @var int|null
-     */
-    public $serializationVersion = null;
+        public ?int $serializationVersion = null,
+    ) {
+        $arrayProperties = [
+            'constraints', 'validationGroups', 'serializationGroups',
+            'serializationAttributes'
+        ];
 
-    /**
-     * @param array $data
-     */
-    public function __construct(array $data)
-    {
-        if (isset($data['value'])) {
-            if (is_array($data['value'])) {
-                $data['name'] = array_shift($data['value']);
-                if (!empty($data['value'])) {
-                    $data['constraints'] = array_shift($data['value']);
-                }
-                if (!empty($data['value'])) {
-                    $data['validationGroups'] = array_shift($data['value']);
-                }
-                if (!empty($data['value'])) {
-                    $data['strict'] = array_shift($data['value']);
-                }
-                if (!empty($data['value'])) {
-                    $data['serializationGroups'] = array_shift($data['value']);
-                }
-                if (!empty($data['value'])) {
-                    $data['serializationAttributes'] = array_shift($data['value']);
-                }
-                if (!empty($data['value'])) {
-                    $data['serializationVersion'] = array_shift($data['value']);
-                }
-            } else {
-                $data['name'] = $data['value'];
+        foreach ($arrayProperties as $property) {
+            if (is_string($$property)) {
+                $this->$property = [$$property];
             }
-            unset($data['value']);
-        }
-
-        foreach ($data as $k => $v) {
-            if ($k == 'constraints' && !is_array($v)) {
-                $v = array($v);
-            } elseif ($k == 'validationGroups' && !is_array($v)) {
-                $v = array($v);
-            } elseif ($k == 'serializationGroups' && !is_array($v)) {
-                $v = array($v);
-            } elseif ($k == 'serializationAttributes' && !is_array($v)) {
-                $v = array($v);
-            }
-
-            $this->{$k} = $v;
         }
     }
 }

--- a/src/Annotation/Result.php
+++ b/src/Annotation/Result.php
@@ -9,6 +9,7 @@
 
 namespace TQ\ExtDirect\Annotation;
 
+use Doctrine\Common\Annotations\NamedArgumentConstructor;
 
 /**
  * Class Result
@@ -17,55 +18,26 @@ namespace TQ\ExtDirect\Annotation;
  *
  * @Annotation
  * @Target("METHOD")
+ * @NamedArgumentConstructor
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 class Result
 {
-    /**
-     * @var array<string>
-     */
-    public $groups = [];
+    public function __construct(
+        /** @var string|array<string> */
+        public string|array $groups = [],
 
-    /**
-     * @var array<string>
-     */
-    public $attributes = [];
+        /** @var string|array<string> */
+        public string|array $attributes = [],
 
-    /**
-     * @var int|null
-     */
-    public $version = null;
+        public ?int $version = null,
+    ) {
+        $arrayProperties = ['groups', 'attributes'];
 
-    /**
-     * @param array $data
-     */
-    public function __construct(array $data)
-    {
-        if (isset($data['value'])) {
-            if (is_array($data['value'])) {
-                $data['groups'] = array_shift($data['value']);
-                if (!empty($data['value'])) {
-                    $data['constraints'] = array_shift($data['value']);
-                }
-                if (!empty($data['value'])) {
-                    $data['attributes'] = array_shift($data['value']);
-                }
-                if (!empty($data['value'])) {
-                    $data['version'] = array_shift($data['value']);
-                }
-            } else {
-                $data['groups'] = $data['value'];
+        foreach ($arrayProperties as $property) {
+            if (is_string($$property)) {
+                $this->$property = [$$property];
             }
-            unset($data['value']);
-        }
-
-        foreach ($data as $k => $v) {
-            if ($k == 'groups' && !is_array($v)) {
-                $v = array($v);
-            } elseif ($k == 'attributes' && !is_array($v)) {
-                $v = array($v);
-            }
-
-            $this->{$k} = $v;
         }
     }
 }

--- a/src/Annotation/Security.php
+++ b/src/Annotation/Security.php
@@ -8,6 +8,8 @@
 
 namespace TQ\ExtDirect\Annotation;
 
+use Doctrine\Common\Annotations\NamedArgumentConstructor;
+
 /**
  * Class Security
  *
@@ -15,13 +17,10 @@ namespace TQ\ExtDirect\Annotation;
  *
  * @Annotation
  * @Target({"CLASS","METHOD"})
+ * @NamedArgumentConstructor
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 class Security
 {
-    /**
-     * @\Doctrine\Common\Annotations\Annotation\Required
-     *
-     * @var string
-     */
-    public $expression;
+    public function __construct(public string $expression) {}
 }

--- a/src/Http/ServiceDescriptionResponse.php
+++ b/src/Http/ServiceDescriptionResponse.php
@@ -41,7 +41,7 @@ class ServiceDescriptionResponse extends JsonResponse
     /**
      * {@inheritdoc}
      */
-    protected function update(): self
+    protected function update(): static
     {
         $this->headers->set('Content-Type', 'application/javascript');
 

--- a/src/Http/UploadResponse.php
+++ b/src/Http/UploadResponse.php
@@ -64,7 +64,7 @@ class UploadResponse extends JsonResponse
     /**
      * {@inheritdoc}
      */
-    protected function update()
+    protected function update(): static
     {
         if ($this->response !== null) {
             $this->headers->set('Content-Type', 'text/html; charset=UTF-8');

--- a/src/Router/RequestFactory.php
+++ b/src/Router/RequestFactory.php
@@ -30,7 +30,7 @@ class RequestFactory
             throw BadRequestException::createMethodNotAllowed($request);
         }
 
-        if ($request->getContentType() == 'json') {
+        if ($request->getContentTypeFormat() == 'json') {
             return $this->createJsonRequest($request);
         } else {
             return $this->createFormRequest($request);

--- a/tests/Description/Services/Service1.php
+++ b/tests/Description/Services/Service1.php
@@ -8,8 +8,11 @@
 
 namespace TQ\ExtDirect\Tests\Description\Services;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraints as Assert;
 use TQ\ExtDirect\Annotation as Direct;
+use TQ\ExtDirect\Router\ArgumentValidationResult;
+use TQ\ExtDirect\Router\Request as ExtDirectRequest;
 
 /**
  * Class Service1
@@ -18,11 +21,13 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action()
  */
+#[Direct\Action()]
 class Service1
 {
     /**
      * @Direct\Method()
      */
+    #[Direct\Method()]
     public function methodA()
     {
     }
@@ -30,6 +35,7 @@ class Service1
     /**
      * @Direct\Method(true)
      */
+    #[Direct\Method(true)]
     public function methodB()
     {
     }
@@ -37,47 +43,41 @@ class Service1
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() })
-     *
-     * @param mixed $a
      */
-    public function methodC($a)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ])]
+    public function methodC(mixed $a)
     {
     }
 
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() })
-     *
-     * @param mixed                                     $a
-     * @param \Symfony\Component\HttpFoundation\Request $request
      */
-    public function methodD($a, \Symfony\Component\HttpFoundation\Request $request)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ])]
+    public function methodD(mixed $a, Request $request)
     {
     }
 
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() })
-     *
-     * @param mixed                        $a
-     * @param \TQ\ExtDirect\Router\Request $request
      */
-    public function methodE($a, \TQ\ExtDirect\Router\Request $request)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ])]
+    public function methodE(mixed $a, ExtDirectRequest $request)
     {
     }
 
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() })
-     *
-     * @param mixed                                     $a
-     * @param \TQ\ExtDirect\Router\Request              $request1
-     * @param \Symfony\Component\HttpFoundation\Request $request2
      */
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ])]
     public function methodF(
-        $a,
-        \TQ\ExtDirect\Router\Request $request1,
-        \Symfony\Component\HttpFoundation\Request $request2
+        mixed $a, ExtDirectRequest $request1, Request $request2
     ) {
     }
 }

--- a/tests/Description/Services/Service2.php
+++ b/tests/Description/Services/Service2.php
@@ -17,6 +17,7 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action()
  */
+#[Direct\Action()]
 class Service2
 {
 

--- a/tests/Description/Services/Service4.php
+++ b/tests/Description/Services/Service4.php
@@ -17,11 +17,13 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action()
  */
+#[Direct\Action()]
 class Service4
 {
     /**
      * @Direct\Method()
      */
+    #[Direct\Method()]
     public function methodA()
     {
     }
@@ -29,6 +31,7 @@ class Service4
     /**
      * @Direct\Method(true)
      */
+    #[Direct\Method(true)]
     public function methodB()
     {
     }

--- a/tests/Metadata/Driver/Services/Service10.php
+++ b/tests/Metadata/Driver/Services/Service10.php
@@ -17,12 +17,15 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action()
  */
+#[Direct\Action()]
 class Service10
 {
     /**
      * @Direct\Method()
      * @Direct\Result(groups={"a", "b"})
      */
+    #[Direct\Method()]
+    #[Direct\Result(groups: ["a", "b"])]
     public function methodA()
     {
     }
@@ -31,6 +34,8 @@ class Service10
      * @Direct\Method()
      * @Direct\Result(attributes={"a": 1, "b": 2})
      */
+    #[Direct\Method()]
+    #[Direct\Result(attributes: ["a" => 1, "b" => 2])]
     public function methodB()
     {
     }
@@ -39,6 +44,8 @@ class Service10
      * @Direct\Method()
      * @Direct\Result(version=1)
      */
+    #[Direct\Method()]
+    #[Direct\Result(version: 1)]
     public function methodC()
     {
     }
@@ -47,6 +54,13 @@ class Service10
      * @Direct\Method()
      * @Direct\Result(groups={"a", "b"}, attributes={"a": 1, "b": 2}, version=1)
      */
+    #[Direct\Method()]
+
+    #[Direct\Result(
+      groups: ["a", "b"],
+      attributes: ["a" => 1, "b" => 2],
+      version: 1
+    )]
     public function methodD()
     {
     }

--- a/tests/Metadata/Driver/Services/Service11.php
+++ b/tests/Metadata/Driver/Services/Service11.php
@@ -18,11 +18,14 @@ use TQ\ExtDirect\Annotation as Direct;
  * @Direct\Action()
  * @Direct\Security("true")
  */
+#[Direct\Action()]
+#[Direct\Security("true")]
 class Service11
 {
     /**
      * @Direct\Method()
      */
+    #[Direct\Method()]
     public function methodA()
     {
     }
@@ -31,6 +34,8 @@ class Service11
      * @Direct\Method()
      * @Direct\Security("true and false")
      */
+    #[Direct\Method()]
+    #[Direct\Security("true and false")]
     public function methodB()
     {
     }
@@ -39,6 +44,8 @@ class Service11
      * @Direct\Method()
      * @Direct\Security(expression="true and true")
      */
+    #[Direct\Method()]
+    #[Direct\Security(expression: "true and false")]
     public function methodC()
     {
     }

--- a/tests/Metadata/Driver/Services/Service12.php
+++ b/tests/Metadata/Driver/Services/Service12.php
@@ -17,17 +17,20 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action()
  */
+#[Direct\Action()]
 class Service12
 {
     /**
      * @Direct\Method(batched=null)
      */
+    #[Direct\Method(batched: null)]
     public function methodA()
     {
     }
     /**
      * @Direct\Method(batched=true)
      */
+    #[Direct\Method(batched: true)]
     public function methodB()
     {
     }
@@ -35,6 +38,7 @@ class Service12
     /**
      * @Direct\Method(batched=false)
      */
+    #[Direct\Method(batched: false)]
     public function methodC()
     {
     }

--- a/tests/Metadata/Driver/Services/Service2.php
+++ b/tests/Metadata/Driver/Services/Service2.php
@@ -17,6 +17,7 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action("app.direct.test")
  */
+#[Direct\Action("app.direct.test")]
 class Service2
 {
 

--- a/tests/Metadata/Driver/Services/Service3.php
+++ b/tests/Metadata/Driver/Services/Service3.php
@@ -17,11 +17,13 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action("app.direct.test")
  */
+#[Direct\Action("app.direct.test")]
 class Service3
 {
     /**
      * @Direct\Method()
      */
+    #[Direct\Method()]
     public function methodA()
     {
     }

--- a/tests/Metadata/Driver/Services/Service4.php
+++ b/tests/Metadata/Driver/Services/Service4.php
@@ -17,11 +17,13 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action()
  */
+#[Direct\Action()]
 class Service4
 {
     /**
      * @Direct\Method(true)
      */
+    #[Direct\Method(true)]
     public function methodB()
     {
     }

--- a/tests/Metadata/Driver/Services/Service5.php
+++ b/tests/Metadata/Driver/Services/Service5.php
@@ -18,85 +18,96 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action("app.direct.test")
  */
+#[Direct\Action("app.direct.test")]
 class Service5
 {
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() })
-     *
-     * @param mixed $a
      */
-    public function methodA($a)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ])]
+    public function methodA(mixed $a)
     {
     }
 
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", constraints={ @Assert\NotNull() })
-     *
-     * @param mixed $a
      */
-    public function methodB($a)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", constraints: [ new Assert\NotNull() ])]
+    public function methodB(mixed $a)
     {
     }
 
     /**
      * @Direct\Method()
      * @Direct\Parameter(name="a", constraints={ @Assert\NotNull() })
-     *
-     * @param mixed $a
      */
-    public function methodC($a)
+    #[Direct\Method()]
+    #[Direct\Parameter(name: "a", constraints: [ new Assert\NotNull() ])]
+    public function methodC(mixed $a)
     {
     }
 
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() }, {"myGroup"})
-     *
-     * @param mixed $a
      */
-    public function methodD($a)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ], [ "myGroup" ])]
+    public function methodD(mixed $a)
     {
     }
 
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() }, validationGroups="myGroup")
-     *
-     * @param mixed $a
      */
-    public function methodE($a)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ], validationGroups: "myGroup" )]
+    public function methodE(mixed $a)
     {
     }
 
     /**
      * @Direct\Method()
      * @Direct\Parameter(name="a", constraints={ @Assert\NotNull() }, validationGroups="myGroup")
-     *
-     * @param mixed $a
      */
-    public function methodF($a)
+    #[Direct\Method()]
+
+    #[Direct\Parameter(
+      name: "a",
+      constraints: [ new Assert\NotNull() ],
+      validationGroups: "myGroup"
+    )]
+    public function methodF(mixed $a)
     {
     }
 
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() }, validationGroups={"myGroup"})
-     *
-     * @param mixed $a
      */
-    public function methodG($a)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ], validationGroups: [ "myGroup" ])]
+    public function methodG(mixed $a)
     {
     }
 
     /**
      * @Direct\Method()
      * @Direct\Parameter(name="a", constraints={ @Assert\NotNull() }, validationGroups={"myGroup"})
-     *
-     * @param mixed $a
      */
-    public function methodH($a)
+    #[Direct\Method()]
+
+    #[Direct\Parameter(
+      name: "a",
+      constraints: [ new Assert\NotNull() ],
+      validationGroups: [ "myGroup" ]
+    )]
+    public function methodH(mixed $a)
     {
     }
 }

--- a/tests/Metadata/Driver/Services/Service7.php
+++ b/tests/Metadata/Driver/Services/Service7.php
@@ -17,11 +17,13 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action()
  */
+#[Direct\Action()]
 class Service7
 {
     /**
      * @Direct\Method()
      */
+    #[Direct\Method()]
     protected function methodA()
     {
     }
@@ -29,6 +31,7 @@ class Service7
     /**
      * @Direct\Method()
      */
+    #[Direct\Method()]
     private function methodB()
     {
     }

--- a/tests/Metadata/Driver/Services/Service8.php
+++ b/tests/Metadata/Driver/Services/Service8.php
@@ -17,11 +17,13 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action()
  */
+#[Direct\Action()]
 class Service8
 {
     /**
      * @Direct\Method()
      */
+    #[Direct\Method()]
     public static function methodA()
     {
     }

--- a/tests/Metadata/Driver/Services/Service9.php
+++ b/tests/Metadata/Driver/Services/Service9.php
@@ -18,15 +18,16 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action()
  */
+#[Direct\Action()]
 class Service9
 {
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() }, strict=true)
-     *
-     * @param string $a
      */
-    public function methodA($a)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ], strict: true)]
+    public function methodA(mixed $a)
     {
     }
 }

--- a/tests/Metadata/Driver/Services/Sub/Service6.php
+++ b/tests/Metadata/Driver/Services/Sub/Service6.php
@@ -18,11 +18,13 @@ use TQ\ExtDirect\Tests\Metadata\Driver\Services\Service4;
  *
  * @Direct\Action("app.direct.test")
  */
+#[Direct\Action("app.direct.test")]
 class Service6 extends Service4
 {
     /**
      * @Direct\Method()
      */
+    #[Direct\Method()]
     public function methodA()
     {
     }

--- a/tests/Metadata/Services/Service1.php
+++ b/tests/Metadata/Services/Service1.php
@@ -19,6 +19,8 @@ use TQ\ExtDirect\Annotation as Direct;
  * @Direct\Action(serviceId="app.direct.test", alias="alias")
  * @Direct\Security("true")
  */
+#[Direct\Action(serviceId: "app.direct.test", alias: "alias")]
+#[Direct\Security("true")]
 class Service1
 {
     /**
@@ -26,11 +28,12 @@ class Service1
      * @Direct\Parameter("a", { @Assert\NotNull() })
      * @Direct\Security("true and true")
      * @Direct\Result(version=1)
-     *
-     * @param mixed $a
-     * @return true
      */
-    public function methodA($a)
+    #[Direct\Method(batched: true)]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ])]
+    #[Direct\Security("true and true")]
+    #[Direct\Result(version: 1)]
+    public function methodA(mixed $a): true
     {
     }
 }

--- a/tests/Router/AuthorizationCheckerTest.php
+++ b/tests/Router/AuthorizationCheckerTest.php
@@ -26,7 +26,7 @@ class AuthorizationCheckerTest extends TestCase
         /** @var \Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface|MockObject $trustResolver */
         $trustResolver = $this->createPartialMock(
             'Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface',
-            ['isAnonymous', 'isRememberMe', 'isFullFledged']
+            ['isAuthenticated', 'isRememberMe', 'isFullFledged']
         );
 
         /** @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface|MockObject $tokenStorage */
@@ -72,7 +72,7 @@ class AuthorizationCheckerTest extends TestCase
         /** @var \Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface|MockObject $trustResolver */
         $trustResolver = $this->createPartialMock(
             'Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface',
-            ['isAnonymous', 'isRememberMe', 'isFullFledged']
+            ['isAuthenticated', 'isRememberMe', 'isFullFledged']
         );
 
         /** @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface|MockObject $tokenStorage */
@@ -115,7 +115,7 @@ class AuthorizationCheckerTest extends TestCase
         /** @var \Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface|MockObject $trustResolver */
         $trustResolver = $this->createPartialMock(
             'Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface',
-            ['isAnonymous', 'isRememberMe', 'isFullFledged']
+            ['isAuthenticated', 'isRememberMe', 'isFullFledged']
         );
 
         /** @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface|MockObject $tokenStorage */

--- a/tests/Router/Services/Service1.php
+++ b/tests/Router/Services/Service1.php
@@ -8,8 +8,11 @@
 
 namespace TQ\ExtDirect\Tests\Router\Services;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraints as Assert;
 use TQ\ExtDirect\Annotation as Direct;
+use TQ\ExtDirect\Router\ArgumentValidationResult;
+use TQ\ExtDirect\Router\Request as ExtDirectRequest;
 
 /**
  * Class Service1
@@ -18,11 +21,13 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action("app.direct.test")
  */
+#[Direct\Action("app.direct.test")]
 class Service1
 {
     /**
      * @Direct\Method()
      */
+    #[Direct\Method()]
     public function methodA()
     {
     }
@@ -30,53 +35,48 @@ class Service1
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() })
-     *
-     * @param mixed $a
      */
-    public function methodB($a)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ])]
+    public function methodB(mixed $a)
     {
     }
 
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() })
-     *
-     * @param mixed                                     $a
-     * @param \Symfony\Component\HttpFoundation\Request $request
      */
-    public function methodC($a, \Symfony\Component\HttpFoundation\Request $request)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ])]
+    public function methodC(mixed $a, Request $request)
     {
     }
 
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() })
-     *
-     * @param mixed                        $a
-     * @param \TQ\ExtDirect\Router\Request $request
      */
-    public function methodD($a, \TQ\ExtDirect\Router\Request $request)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ])]
+    public function methodD(mixed $a, ExtDirectRequest $request)
     {
     }
 
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() })
-     *
-     * @param mixed                                     $a
-     * @param \TQ\ExtDirect\Router\Request              $request1
-     * @param \Symfony\Component\HttpFoundation\Request $request2
      */
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ])]
     public function methodE(
-        $a,
-        \TQ\ExtDirect\Router\Request $request1,
-        \Symfony\Component\HttpFoundation\Request $request2
+        mixed $a, ExtDirectRequest $request1, Request $request2
     ) {
     }
 
     /**
      * @Direct\Method()
      */
+    #[Direct\Method()]
     public static function methodF()
     {
     }
@@ -84,22 +84,20 @@ class Service1
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() })
-     *
-     * @param mixed                                         $a
-     * @param \TQ\ExtDirect\Router\ArgumentValidationResult $result
      */
-    public function methodG($a, \TQ\ExtDirect\Router\ArgumentValidationResult $result = null)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ])]
+    public function methodG(mixed $a, ArgumentValidationResult $result = null)
     {
     }
 
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull() })
-     *
-     * @param mixed                                         $a
-     * @param \TQ\ExtDirect\Router\ArgumentValidationResult $result
      */
-    public function methodH($a, \TQ\ExtDirect\Router\ArgumentValidationResult $result)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull() ])]
+    public function methodH(mixed $a, ArgumentValidationResult $result)
     {
     }
 }

--- a/tests/Router/Services/Service2.php
+++ b/tests/Router/Services/Service2.php
@@ -8,7 +8,9 @@
 
 namespace TQ\ExtDirect\Tests\Router\Services;
 
+use Symfony\Component\HttpFoundation\Request;
 use TQ\ExtDirect\Annotation as Direct;
+use TQ\ExtDirect\Router\Request as ExtDirectRequest;
 
 /**
  * Class Service2
@@ -19,29 +21,25 @@ class Service2
 {
     /**
      * @Direct\Method(true)
-     *
-     * @param \Symfony\Component\HttpFoundation\Request $request
      */
-    public function methodA(\Symfony\Component\HttpFoundation\Request $request)
+    #[Direct\Method(true)]
+    public function methodA(Request $request)
     {
     }
 
     /**
      * @Direct\Method(true)
-     *
-     * @param \TQ\ExtDirect\Router\Request $request
      */
-    public function methodB(\TQ\ExtDirect\Router\Request $request)
+    #[Direct\Method(true)]
+    public function methodB(ExtDirectRequest $request)
     {
     }
 
     /**
      * @Direct\Method(true)
-     *
-     * @param \TQ\ExtDirect\Router\Request              $request1
-     * @param \Symfony\Component\HttpFoundation\Request $request2
      */
-    public function methodC(\TQ\ExtDirect\Router\Request $request1, \Symfony\Component\HttpFoundation\Request $request2)
+    #[Direct\Method(true)]
+    public function methodC(ExtDirectRequest $request1, Request $request2)
     {
     }
 }

--- a/tests/Service/Services/Service1.php
+++ b/tests/Service/Services/Service1.php
@@ -18,14 +18,14 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action("app.direct.test")
  */
+#[Direct\Action("app.direct.test")]
 class Service1
 {
     /**
      * @Direct\Method()
-     *
-     * @param mixed $a
      */
-    public function methodA($a)
+    #[Direct\Method()]
+    public function methodA(mixed $a)
     {
     }
 }

--- a/tests/Service/Services/Service2.php
+++ b/tests/Service/Services/Service2.php
@@ -18,14 +18,14 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action()
  */
+#[Direct\Action()]
 class Service2
 {
     /**
      * @Direct\Method()
-     *
-     * @param mixed $a
      */
-    public function methodA($a)
+    #[Direct\Method()]
+    public function methodA(mixed $a)
     {
     }
 }

--- a/tests/Service/Services/Service3.php
+++ b/tests/Service/Services/Service3.php
@@ -20,6 +20,7 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action()
  */
+#[Direct\Action()]
 class Service3 implements ContainerAwareInterface
 {
     protected ?ContainerInterface $container;
@@ -27,6 +28,7 @@ class Service3 implements ContainerAwareInterface
     /**
      * @Direct\Method()
      */
+    #[Direct\Method()]
     public function methodA(mixed $a)
     {
     }

--- a/tests/Service/Services/Service3.php
+++ b/tests/Service/Services/Service3.php
@@ -9,7 +9,7 @@
 namespace TQ\ExtDirect\Tests\Service\Services;
 
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use TQ\ExtDirect\Annotation as Direct;
 
@@ -22,21 +22,21 @@ use TQ\ExtDirect\Annotation as Direct;
  */
 class Service3 implements ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    protected ?ContainerInterface $container;
 
     /**
      * @Direct\Method()
-     *
-     * @param mixed $a
      */
-    public function methodA($a)
+    public function methodA(mixed $a)
     {
     }
 
-    /**
-     * @return \Symfony\Component\DependencyInjection\ContainerInterface
-     */
-    public function getContainer()
+    public function setContainer(?ContainerInterface $container = null): void
+    {
+        $this->container = $container;
+    }
+
+    public function getContainer(): ContainerInterface
     {
         return $this->container;
     }

--- a/tests/Service/Services/Service4.php
+++ b/tests/Service/Services/Service4.php
@@ -18,24 +18,18 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action()
  */
+#[Direct\Action()]
 class Service4
 {
-    /**
-     * @param $a
-     * @param $b
-     * @param $c
-     * @param $d
-     */
     public function __construct($a, $b, $c, $d)
     {
     }
 
     /**
      * @Direct\Method()
-     *
-     * @param mixed $a
      */
-    public function methodA($a)
+    #[Direct\Method()]
+    public function methodA(mixed $a)
     {
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,4 +11,6 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 
 $loader = require __DIR__ . '/../vendor/autoload.php';
 
-AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
+if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
+    AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+}


### PR DESCRIPTION
Tested with PHP 8.2.x.

All annotation tests passed.

If you replace 
```
use Doctrine\Common\Annotations\AnnotationReader;
```
with
```
use Koriym\Attributes\AttributeReader as AnnotationReader;
```
in
```
tests/Description/ServiceDescriptionFactoryTest.php
tests/Metadata/ActionMetadataTest.php
tests/Metadata/Driver/AnnotationDriverTest.php
tests/Metadata/MethodMetadataTest.php
tests/Router/ServiceResolverTest.php
tests/Service/ContainerServiceFactoryTest.php
```
then all attribute tests will pass too.

I don't know how to make both (annotation and attribute tests) work in a single run.
